### PR TITLE
替换 USTC 的镜像为官方镜像，因为该脚本的执行环境大部分为国外环境。

### DIFF
--- a/scripts/install.ubuntu.18.04.sh
+++ b/scripts/install.ubuntu.18.04.sh
@@ -53,9 +53,9 @@ install_bbr() {
 install_docker() {
     if ! [ -x "$(command -v docker)" ]; then
         echo "开始安装 Docker CE"
-        curl -fsSL https://mirrors.ustc.edu.cn/docker-ce/linux/ubuntu/gpg | sudo apt-key add -
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository \
-            "deb [arch=amd64] https://mirrors.ustc.edu.cn/docker-ce/linux/ubuntu \
+            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
             $(lsb_release -cs) \
             stable"
         sudo apt-get update -qq


### PR DESCRIPTION
replace ustc mirros to official