### PR TITLE
fix(scripts): remove redundant slash of `CERT_DIR`

### DIFF
--- a/scripts/install.ubuntu.18.04.sh
+++ b/scripts/install.ubuntu.18.04.sh
@@ -129,7 +129,7 @@ install_gost() {
     fi
 
     BIND_IP=0.0.0.0
-    CERT_DIR=/etc/letsencrypt/
+    CERT_DIR=/etc/letsencrypt
     CERT=${CERT_DIR}/live/${DOMAIN}/fullchain.pem
     KEY=${CERT_DIR}/live/${DOMAIN}/privkey.pem
 


### PR DESCRIPTION
when run `Gost` service, it will go to `/etc/letsencrypt//live/xxx/` to find cert files.