### PR TITLE
gost 服务端部分增加 auth参数 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ sudo docker run -d --name gost \
 
 **注意**：开启了探测防御功能后，当认证失败时服务器默认不会响应 `407 Proxy Authentication Required`，但某些情况下客户端需要服务器告知代理是否需要认证(例如Chrome中的 SwitchyOmega 插件)。通过knock参数设置服务器才会发送407响应。对于上面的例子，我们的`knock`参数配置的是`www.google.com`，所以，你需要先访问一下 `https://www.google.com` 让服务端返回一个 `407` 后，SwitchyOmega 才能正常工作。
 
+**注意**：如果认证信息（也就是用户名和密码）中包含特殊字符，则可以（应该是必须！否则客户端一侧会有很多不兼容）通过auth参数来设置：
+```
+gost -L :8080?auth=YWRtaW46MTIzNDU2 -F ss://:8338?auth=Y2hhY2hhMjA6QWEjJiEkMTIzNEA1Njc4
+```
+auth的值为user:passbase64编码值
+
+
 如无意外，你的服务就启起来了。你可以使用下面的命令验证你的 gost 服务是否正常。
 
 ```shell


### PR DESCRIPTION
实际使用中发现使用 auth参数 能避免大部分客户端不兼容的情况。