### PR TITLE
修改3.3.2服务器端指令

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ curl -v "https://www.google.com" --proxy "https://DOMAIN" --proxy-user 'USER:PAS
 
 服务器端：
 ```
-gost -L=mwss://username:password@:443?cert=/path/to/your/cert/file\&key=/path/to/your/key/file
+gost -L=mwss://username:password@:443?cert=/path/to/your/cert/file&key=/path/to/your/key/file
 ```
 
 CloudFlare：将TLS/SSL设置为**完全**


### PR DESCRIPTION
在芯片为M1 Pro、系统为macOS Monterey12.6的MacBook Pro上执行 gost -L=mwss://username:password@:443?cert=/path/to/your/cert/file\\&key=/path/to/your/key/file 会报 2022/10/07 15:34:45 main.go:90: open /etc/letsencrypt/live/fq.x.com/fullchain.pem: permission denied  错误，将\\&的\去掉即 gost -L=mwss://username:password@:443?cert=/path/to/your/cert/file&key=/path/to/your/key/file 则能正常运行。