### PR TITLE
添加 Lightsail 试用信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 科学上网
 
 作者：左耳朵 [http://coolshell.cn](http://coolshell.cn)
-更新时间：2022-11-15
+更新时间：2022-11-23
 
 这篇文章可以写的更好，欢迎到 [https://github.com/haoel/haoel.github.io](https://github.com/haoel/haoel.github.io) 更新
 
@@ -98,7 +98,7 @@
 
 对于 VPS，下面是一些常规选项。
 
-- [AWS LightSail](https://lightsail.aws.amazon.com/) 是一个非常便宜好用的服务，最低配置一个月 $3.5 美金，流量不限，目前的Zone不多，推荐使用日本，新加坡或美国俄勒冈（支持银联卡）
+- [AWS LightSail](https://lightsail.aws.amazon.com/) 是一个非常便宜好用的服务，最低配置一个月 $3.5 美金，流量不限，目前的Zone不多，推荐使用日本，新加坡或美国俄勒冈（支持银联卡）。现对 2021/8/7 之后使用 Lightsail 的用户提供3个月的免费试用。
 - [AWS EC2](https://aws.amazon.com/cn/)香港、日本或韩国申请个免费试用一年的EC2 VPS （支持银联卡）
 - [Google Cloud Platform](https://cloud.google.com/)提供免费试用，赠送300刀赠金（需要国际信用卡）
 - [Linode](https://www.linode.com)买个一月USD5刀的VPS


### PR DESCRIPTION
从 Lightsail 的[价格页面](https://aws.amazon.com/lightsail/pricing/)了解到亚马逊现在限期内提供为期3个月的免费试用

> For a limited time, Lightsail is extending its free tier to include three months free on select bundles. The offer applies to new or existing AWS accounts that started Lightsail usage on or after 7/8/2021. Offer only applies to one bundle per account. Standard charges apply after first 750 hours of usage of the selected bundle each month. 

> Three months free on Linux/Unix bundles: $3.50 USD/month, $5 USD/month, and $10 USD/month