### PR TITLE
补充 windows下git 的ssh 代理配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,8 @@ with_proxy(){
 Host github.com
     Hostname github.com
     ProxyCommand nc -x localhost:1085 %h %p
+    # git-for-windows 下可以用 connect 代替 nc
+    # ProxyCommand connect -S localhost:1085 %h %p
 ```
 
 


### PR DESCRIPTION
ncat 也行就是有的版本有点小问题
https://superuser.com/questions/714845/tunneling-ssh-via-a-socks5-proxy-on-windows