### PR TITLE
Fix Gost bypass configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,7 +1190,7 @@ docker run --rm curlimages/curl --connect-timeout 2 -x "socks5://172.17.0.2:4000
 接下来我们给 Gost 增加一个条件转发规则，转发我们希望的域名、地址到 cloudflare 的 warp 网络:
 
 ```
--F=socks5://172.17.0.2:40001?notls=true&bypass=~*.openai.com,openai.com
+-F=socks5://172.17.0.2:40001?bypass=~*.openai.com,openai.com&notls=true
 ```
 
 `bypass=~` 的含义是，只有命中后面规则时才转发请求到 `172.17.0.2:40001` 这个 socks5 代理。


### PR DESCRIPTION
There is a bug with the `bypass` parameter in Gost v2, it must be placed first in the parameter list or it will fail, this issue is not fixed yet. 

So the current configuration will cause all requests to be forwarded to Warp, which is not what we expected. This PR should fix the issue. 

I haven't tested v3, so I'm not sure if the same problem exists. See the following tests for details:

```shell
root@easy-drum-1:~/bypass-gfw# docker ps
CONTAINER ID   IMAGE                   COMMAND                  CREATED             STATUS             PORTS     NAMES
0dce6bb96e31   ginuerzh/gost           "/bin/gost -L http:/…"   19 seconds ago      Up 18 seconds                gost
32a193758b08   e7h4n/cloudflare-warp   "/bin/startup.sh"        About an hour ago   Up About an hour             cloudflare-warp
root@easy-drum-1:~/bypass-gfw#
root@easy-drum-1:~/bypass-gfw# tail -n4 gost.sh
docker run -d --name gost \
  --net=host ginuerzh/gost \
 -L http://:8080 \
 -F socks5://172.17.0.2:40001?notls=true&bypass=~*.openai.com,openai.com
root@easy-drum-1:~/bypass-gfw#
root@easy-drum-1:~/bypass-gfw# docker run --rm curlimages/curl --connect-timeout 2 -x "http://172.17.0.1:8080" ipinfo.io
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{
  "ip": "104.28.195.186",
  "city": "Los Angeles",
  "region": "California",
  "country": "US",
  "loc": "34.0522,-118.2437",
  "org": "AS13335 Cloudflare, Inc.",
  "postal": "90009",
  "timezone": "America/Los_Angeles",
  "readme": "https://ipinfo.io/missingauth"
100   268  100   268    0     0   3934      0 --:--:-- --:--:-- --:--:--  3941
root@easy-drum-1:~/bypass-gfw#
root@easy-drum-1:~/bypass-gfw# vim gost.sh
root@easy-drum-1:~/bypass-gfw# tail -n4 gost.sh
docker run -d --name gost \
  --net=host ginuerzh/gost \
 -L http://:8080 \
 -F socks5://172.17.0.2:40001?bypass=~*.openai.com,openai.com&notls=true
root@easy-drum-1:~/bypass-gfw# ./gost.sh > /dev/null
root@easy-drum-1:~/bypass-gfw# docker run --rm curlimages/curl --connect-timeout 2 -x "http://172.17.0.1:8080" ipinfo.io
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   298  100   298    0     0   5223      0 --:--:-- --:--:-- --{--:--     0
  "ip": "199.*.*.*",
  "hostname": "199.*.*.*",
  "city": "Los Angeles",
  "region": "California",
  "country": "US",
  "loc": "*,*",
  "org": "AS21887 Fiber Logic Inc.",
  "postal": "90017",
  "timezone": "America/Los_Angeles",
  "readme": "https://ipinfo.io/missingauth"
}:--:--  5321
```