### PR TITLE
fix gost default port error

### DIFF
--- a/scripts/install.ubuntu.18.04.sh
+++ b/scripts/install.ubuntu.18.04.sh
@@ -177,7 +177,7 @@ install_shadowsocks(){
 
     BIND_IP=0.0.0.0
 
-    if [[ -z "${PORT// }" ]] || ! [[ "${PORT}" =~ ^[0-9]+$ ]] || ! [ "$PORT" -ge 1 ] && [  "$PORT" -le 655535 ]; then
+    if [[ -z "${PORT// }" ]] || ! [[ "${PORT}" =~ ^[0-9]+$ ]] || ! ([ "$PORT" -ge 1 ] && [  "$PORT" -le 65535 ]); then
         echo -e "${COLOR_ERROR}非法端口,使用默认端口 1984 !${COLOR_NONE}"
         PORT=1984
     fi


### PR DESCRIPTION
在指定gost监听的 http2 端口时，如果不输入端口直接回车，由于 shell 脚本运算符优先级的原因，端口校验代码会报错，无法正确的使用默认的443端口，会出现下面的报错，无法启动容器：
```
[: : integer expression expected
```
修复：
1. 添加了括号调整运算符优先级，修复对端口号的校验
2. 修改端口号上限为 65535