### PR TITLE
增加 android ss 客户端 gost 插件配置指引

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ gost -L ss://aes-128-gcm:passcode@:1984 -F 'https://USER:PASS@DOMAIN:443'
 对于手机端
 
  - iPhone，可以考虑使用 `ShadowRocket` （需要付费），其中使用 HTTPS 的代理，配置上就好了。
- - Android，可以考虑使用这个Plugin - [ShadowsocksGostPlugin](https://github.com/xausky/ShadowsocksGostPlugin)
+ - Android，可以考虑使用这个Plugin - [ShadowsocksGostPlugin](https://github.com/xausky/ShadowsocksGostPlugin)，参考 [#33](https://github.com/xausky/ShadowsocksGostPlugin/issues/33) 进行配置
 
 **注明**：如果你之前使用了Chrome插件 SwitchyOmega，如果无法直接配置HTTPS代理，具体原因可能是因为你设置了`probe_resist`以开启探测防御功能。这里，你需要在服务器端设置 `knock` 参数（参看 [用 Gost 设置 HTTPS 服务](#33-用-gost-设置-https-服务) 中的“注意”一节 ）
 


### PR DESCRIPTION
原仓库配置说明无法使用，参考 [#33](https://github.com/xausky/ShadowsocksGostPlugin/issues/33) 进行配置